### PR TITLE
[deprecated] update tap tearDown method

### DIFF
--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -37,7 +37,7 @@ t.test('testnode', async t => {
     MICROSERVICE_GATEWAY_SERVICE_NAME: 'microservice-gateway.example.org',
   })
 
-  t.tearDown(async() => {
+  t.teardown(async() => {
     await fastify.close()
   })
 


### PR DESCRIPTION
Modified `tap.tearDown` method with the non-deprecated one `tap.teardown`